### PR TITLE
Fix regression regarding installing repos with custom tag

### DIFF
--- a/libexec/basher-install
+++ b/libexec/basher-install
@@ -61,6 +61,9 @@ fi
 
 if [[ "$package" = */*@* ]]; then
   IFS=@ read -r package ref <<< "$package"
+  if [ "$custom_folder" = "false" ]; then
+    folder="$package"
+  fi
 else
   ref=""
 fi

--- a/tests/basher-install.bats
+++ b/tests/basher-install.bats
@@ -81,6 +81,10 @@ basher-_link-completions username/package"
   run basher-install username/package@v1.2.3
 
   assert_line "basher-_clone false github.com username/package v1.2.3"
+  assert_line "basher-_deps username/package"
+  assert_line "basher-_link-bins username/package"
+  assert_line "basher-_link-man username/package"
+  assert_line "basher-_link-completions username/package"
 }
 
 @test "empty version is ignored" {


### PR DESCRIPTION
As per https://github.com/basherpm/basher/issues/130, running something like 

```basher install UrbanCompass/hnvm@v0.15.10``` 

would result in an error like 

```find: /Users/joseph.galindo/.basher/cellar/packages/UrbanCompass/hnvm@v0.15.10: No such file or directory```

This regression was introduced in e4fea83da3cec5f201d6c8f07374908ad7813009. (By me 😅). The version is stripped from the package name but not from the folder name. Thus there is a mismatch and the linking fails.

I've also enhanced one of the test cases to catch this in future